### PR TITLE
[feat] redirecionamento para a documentação swagger

### DIFF
--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -122,6 +122,13 @@ public class Startup
 
         app.UseEndpoints(endpoints =>
         {
+                endpoints.MapGet("/", context =>
+                {
+                        context.Response.Redirect("/swagger/index.html");
+                        return Task.CompletedTask;
+                });
+
+                
                 #region Home
                 endpoints.MapGet("/", () => Results.Json(new Home()))
                         .AllowAnonymous()


### PR DESCRIPTION
Agora será possivel ir diretamente para a documentação do swagger sem precisar inserir manualmente o /swagger